### PR TITLE
Send referral data to EAL

### DIFF
--- a/src/phishing.html
+++ b/src/phishing.html
@@ -37,6 +37,13 @@ a {
       ga('create', 'UA-37075177-6', 'auto');
       ga('send', 'pageview');
 
+      //Send referral data to EAL
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+      ga('create', 'UA-68598031-1', 'metamask.io');
+      ga('send', 'pageview');
     </script>
 
   </head>

--- a/src/phishing.html
+++ b/src/phishing.html
@@ -42,8 +42,10 @@ a {
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
       m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
       })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-      ga('create', 'UA-68598031-1', 'metamask.io');
+      ga('create', 'UA-68598031-1', 'auto' {'allowLinker':true});
       ga('send', 'pageview');
+      ga('require', 'linker');
+      ga('linker:autoLink', ['harrydenley.com', 'metamask.io'], false, true);
     </script>
 
   </head>


### PR DESCRIPTION
Sends referral data to EAL GA so we can easily look at current phishing campaigns work more efficiently at takedowns.