### PR TITLE
Add other browser links

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "homepage": "https://github.com/MetaMask/landing#readme",
   "dependencies": {
+    "detect-browser": "^2.0.0",
     "node-static": "^0.7.7"
   },
   "devDependencies": {

--- a/src/index.html
+++ b/src/index.html
@@ -48,7 +48,9 @@
         <h1>MetaMask</h1>
         <h2>Brings Ethereum to your browser </h2>
 
-        <a href="https://chrome.google.com/webstore/detail/nkbihfbeogaeaoehlefnkodbefgpgknn" class="cta" target="_blank">Get Chrome Plugin</a>
+        <a href="https://chrome.google.com/webstore/detail/nkbihfbeogaeaoehlefnkodbefgpgknn" id="install-button" class="cta" target="_blank">Get Chrome Plugin</a>
+        <p>OR</p>
+        <a href="https://brave.com/" class="cta" target="_blank">Get Brave</a>
 
     </section>
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,7 +1,24 @@
 var ModelViewer = require('metamask-logo')
+var detect = require('detect-browser').detect
 var isMobile = !!detectMobile()
 
+showCorrectButton()
 injectMascot()
+
+function showCorrectButton(){
+  const browser = detect()
+
+  typeof window.web3 // Touching the web3 object to trigger Brave prompting to install.
+
+  switch (browser.name) {
+    case 'firefox':
+      var link = document.querySelector('#install-button')
+      var firefoxLink = 'https://addons.mozilla.org/en-US/firefox/addon/ether-metamask/'
+      link.innerText = 'Get Firefox Addon'
+      link.href = firefoxLink
+      break
+  }
+}
 
 function injectMascot(){
   // get container from DOM


### PR DESCRIPTION
Always show "Get Brave" option (cannot be detected for privacy).
Detect firefox, show firefox link instead of Chrome link when on Firefox.